### PR TITLE
Add unstyled wallet login

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+import Providers from "@/components/Provider";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -27,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,31 +1,36 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
+import { LoginButton } from "@/components/LoginButton";
 
 export default function Home() {
   const { messages, input, handleInputChange, handleSubmit } = useChat();
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
-      {messages.map((message) => (
-        <div key={message.id} className="whitespace-pre-wrap">
-          {message.role === "user" ? "User: " : "AI: "}
-          {message.parts.map((part, i) => {
-            switch (part.type) {
-              case "text":
-                return <div key={`${message.id}-${i}`}>{part.text}</div>;
-            }
-          })}
-        </div>
-      ))}
+    
+    <>
+    <LoginButton />
+      <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+        {messages.map((message) => (
+          <div key={message.id} className="whitespace-pre-wrap">
+            {message.role === "user" ? "User: " : "AI: "}
+            {message.parts.map((part, i) => {
+              switch (part.type) {
+                case "text":
+                  return <div key={`${message.id}-${i}`}>{part.text}</div>;
+              }
+            })}
+          </div>
+        ))}
 
-      <form onSubmit={handleSubmit}>
-        <input
-          className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl"
-          value={input}
-          placeholder="Say something..."
-          onChange={handleInputChange}
-        />
-      </form>
-    </div>
+        <form onSubmit={handleSubmit}>
+          <input
+            className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl"
+            value={input}
+            placeholder="Say something..."
+            onChange={handleInputChange}
+          />
+        </form>
+      </div>
+    </>
   );
 }

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -1,0 +1,28 @@
+import { useLogin, usePrivy } from "@privy-io/react-auth";
+import { useSolanaWallets } from "@privy-io/react-auth/solana";
+
+export function LoginButton() {
+  const { ready, authenticated, logout } = usePrivy();
+  const { login } = useLogin();
+  const { wallets } = useSolanaWallets();
+
+  // Disable login when Privy is not ready or the user is already authenticated
+  const disableLogin = !ready || (ready && authenticated);
+
+  // Disable logout when Privy is not ready or the user is not authenticated
+  const showLogout = ready && authenticated;
+
+  if (!ready) {
+    return <div>Loading...</div>;
+  }
+
+  if (showLogout) {
+    return <button onClick={logout}>Log out </button>;
+  }
+
+  return (
+    <button disabled={disableLogin} onClick={login}>
+      Log in
+    </button>
+  );
+}

--- a/components/Provider.tsx
+++ b/components/Provider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { PrivyProvider } from "@privy-io/react-auth";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <PrivyProvider
+      appId="cm9heti9z01ell70lye6yiwlj"
+      clientId="client-WY5iuNEjg97LH3Zhfa1eu3Leb4tkezN9a1xZ7GPHFXygV"
+      config={{
+        // Customize Privy's appearance in your app
+        appearance: {
+          theme: "light",
+          accentColor: "#676FFF",
+          logo: "https://your-logo-url",
+        },
+        // Create embedded wallets for users who don't have a wallet.
+        embeddedWallets: {
+          solana: { createOnLogin: "users-without-wallets" },
+        },
+      }}
+    >
+      {children}
+    </PrivyProvider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.3.11",
     "@ai-sdk/react": "^1.2.9",
+    "@privy-io/react-auth": "^2.9.1",
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.0",
     "ai": "^4.3.6",


### PR DESCRIPTION
## 🚀 Description, Motivation, and Context

<!--
  Describe your changes in detail. Why is this change is required? What problem does it solve?
  Screenshots and fun icons are welcome 🎉
-->

This creates the unstyled login and logout functionality with wallet from _Privy_. The rest of the styling will come in a follow-up PR.

Login button currently:

<img width="258" alt="Screenshot 2025-04-14 at 11 54 31 PM" src="https://github.com/user-attachments/assets/4ebf95c8-98a0-47ee-9848-299a5bd7d59e" />

## 📖 Related PRs

<!--
  Link any related Notion issues, Github issues, or related Pull Requests.
  If the PR closes any open PRs or issues, use [closing words](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by this PR
-->
- https://www.notion.so/meowydev/Create-Login-with-Wallet-Check-Privy-Dynamic-or-Web3Auth-1d5e20a11b62808ca5d0ecd49ded7544?pvs=4
<!-- - **Github issue:** #0, Closes #1, Closes #5 <!-- -->
<!-- - **Related PR:** #286 <!-- -->

## 🌮 How This Was Tested

<!--
  Describe the before and after of how your change was tested/confirmed as working correctly.
-->
  Happy Path(s):
  1. User visits `/`.
  2. Expect to see the super minimalistic **Log in** unstyled button.
  3. User clicks on the **Log in** button.
  4. User enters their email address.
  5. Expect to receive confirmation code sent to the email address.
  6. User enters the received confirmation code from their email address in the modal.
  7. Expect to be logged in.
